### PR TITLE
re-add greek mirror

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = chaotic-mirrorlist
 	pkgdesc = Chaotic-AUR mirrorlist to use with Pacman
-	pkgver = 20230223
-	pkgrel = 1
+	pkgver = 20230304
+	pkgrel = 2
 	url = https://aur.chaotic.cx
 	arch = any
 	license = GPL
 	backup = etc/pacman.d/chaotic-mirrorlist
 	source = mirrorlist
-	sha256sums = df59463721aba068c21072b7d57663af40a13a38a6926aabbaf7d87e43f44424
+	sha256sums = 930d4a15eaecb1157636170697b929ce1181707d19564fdc5b003e0e4711f26b
 
 pkgname = chaotic-mirrorlist

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=chaotic-mirrorlist
 pkgver=20230304
-pkgrel=1
+pkgrel=2
 pkgdesc="Chaotic-AUR mirrorlist to use with Pacman"
 arch=('any')
 url="https://aur.chaotic.cx"
@@ -29,4 +29,4 @@ package() {
   install -m644 "$srcdir/mirrorlist" "$pkgdir/etc/pacman.d/chaotic-mirrorlist"
 }
 
-sha256sums=('3b278f3ee3fa1681320fc0169131242625d0e96170f38b0e190d3a7e4dffce6c')
+sha256sums=('930d4a15eaecb1157636170697b929ce1181707d19564fdc5b003e0e4711f26b')

--- a/mirrorlist
+++ b/mirrorlist
@@ -37,6 +37,10 @@ Server = https://de-3-mirror.chaotic.cx/$repo/$arch
 # * By: redgloboli
 Server = https://de-4-mirror.chaotic.cx/$repo/$arch
 
+# Greece
+# * By: vmmaniac <github.com/vmmaniac>
+Server = https://gr-mirror.chaotic.cx/$repo/$arch
+
 # India
 # * By Naman (Kaithal)
 Server = https://in-mirror.chaotic.cx/$repo/$arch


### PR DESCRIPTION
The greek mirror was accidentally deleted during the last commit, probably by copy-pasting the contents from the mirrorlist.txt file of the chaotic-aur.github.io repo that didn't have the new mirror added. 