### PR TITLE
fix us-mi-2 Silky.Network

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = chaotic-mirrorlist
 	pkgdesc = Chaotic-AUR mirrorlist to use with Pacman
 	pkgver = 20230422
-	pkgrel = 1
+	pkgrel = 2
 	url = https://aur.chaotic.cx
 	arch = any
 	license = GPL
 	backup = etc/pacman.d/chaotic-mirrorlist
 	source = mirrorlist
-	sha256sums = 26691c7817f6b2d9454e787c8bed8a17dc1d83fbcd78e80515649b744f6dbd2c
+	sha256sums = 0e32193cd55c76398fa885e804d4854f5b9970ffd9bd6dc278ba038b647e8c71
 
 pkgname = chaotic-mirrorlist

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=chaotic-mirrorlist
 pkgver=20230422
-pkgrel=1
+pkgrel=2
 pkgdesc="Chaotic-AUR mirrorlist to use with Pacman"
 arch=('any')
 url="https://aur.chaotic.cx"
@@ -29,4 +29,4 @@ package() {
   install -m644 "$srcdir/mirrorlist" "$pkgdir/etc/pacman.d/chaotic-mirrorlist"
 }
 
-sha256sums=('26691c7817f6b2d9454e787c8bed8a17dc1d83fbcd78e80515649b744f6dbd2c')
+sha256sums=('0e32193cd55c76398fa885e804d4854f5b9970ffd9bd6dc278ba038b647e8c71')

--- a/mirrorlist
+++ b/mirrorlist
@@ -168,7 +168,7 @@ Server = https://us-fl-mirror.chaotic.cx/$repo/$arch
 # * By: Technetium1 <github.com/Technetium1>
 Server = https://us-mi-mirror.chaotic.cx/$repo/$arch
 # * By: Silky.Network (Chicago, US)
-Server = https://us-mi-mirror.chaotic.cx/$repo/$arch
+Server = https://us-mi-2-mirror.chaotic.cx/$repo/$arch
 # New York
 # * By: Eduard <t.me/edu4rdshl>
 Server = https://us-ny-mirror.chaotic.cx/$repo/$arch


### PR DESCRIPTION
us-mi points to @Technetium1 's [mirror](https://chaoticmirror.com) instead of @a0xz 's Silky.Network [mirror](https://ord-us-mirror.silky.network)